### PR TITLE
Update test to use 'White' as vehicle color

### DIFF
--- a/src/fiap-catalog-service-tests/VehicleEndpointsTests.cs
+++ b/src/fiap-catalog-service-tests/VehicleEndpointsTests.cs
@@ -79,7 +79,7 @@ namespace fiap_catalog_service_tests
         public async Task UpdateVehicle_ReturnsOkResult_WhenVehicleIsUpdated()
         {
             // Arrange          
-            var vehicle = new Vehicle { Model = "Corolla", Brand = "Toyota", Color = "Gray", Year = 2019, Price = 20000 };
+            var vehicle = new Vehicle { Model = "Corolla", Brand = "Toyota", Color = "White", Year = 2019, Price = 20000 };
             _validatorMock.Setup(v => v.Validate(vehicle)).Returns(new FluentValidation.Results.ValidationResult());
             _vehicleServiceMock.Setup(s => s.UpdateVehicleAsync(vehicle.Id, vehicle)).ReturnsAsync(vehicle);
 


### PR DESCRIPTION
Modified the `UpdateVehicle_ReturnsOkResult_WhenVehicleIsUpdated` test in `VehicleEndpointsTests.cs` to change the `Color` property of the `vehicle` object from "Gray" to "White". This aligns the test data with updated requirements or scenarios.