### PR TITLE
Update .gitignore and add coverlet.msbuild package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -405,3 +405,6 @@ src/volume/
 
 # AWS SAM Template
 .aws-sam
+
+# Arquivos SonarQube
+src/.sonarqube

--- a/src/fiap-catalog-service-tests/fiap-catalog-service-tests.csproj
+++ b/src/fiap-catalog-service-tests/fiap-catalog-service-tests.csproj
@@ -17,6 +17,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.5.3" />


### PR DESCRIPTION
- Updated `.gitignore` to include `src/.sonarqube` to prevent tracking.
- Added `coverlet.msbuild` package reference (v6.0.4) to `fiap-catalog-service-tests.csproj` for improved code coverage support.