### PR TITLE
Refactor namespace and update Lambda handler

### DIFF
--- a/src/fiap-catalog-service-consumers/ReserveVehicleFunction/Function.cs
+++ b/src/fiap-catalog-service-consumers/ReserveVehicleFunction/Function.cs
@@ -10,7 +10,7 @@ using System.Text.Json;
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
 [assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 
-namespace fiap_catalog_service_consumers.ReserveVehicleFunction;
+namespace catalog.Reserve;
 
 [ExcludeFromCodeCoverage]
 public class Function

--- a/template.yaml
+++ b/template.yaml
@@ -47,7 +47,7 @@ Resources:
     Properties:
       FunctionName: fiap-reservar-veiculo
       CodeUri: ./src/fiap-catalog-service-consumers/
-      Handler: fiap_catalog_service_consumers.ReserveVehicleFunction::fiap_catalog_service_consumers.ReserveVehicleFunction.Function::FunctionHandler
+      Handler: catalog.Reserve::catalog.Reserve.Function::FunctionHandler
       Events:
         SQSTrigger:
           Type: SQS


### PR DESCRIPTION
Changed the namespace of the `Function` class in `Function.cs` from `fiap_catalog_service_consumers.ReserveVehicleFunction` to `catalog.Reserve` for better organization. Updated the `Handler` property in `template.yaml` to reflect the new namespace, ensuring the AWS Lambda function points to the correct handler.