### PR TITLE
Refactor unreserve vehicle functionality

### DIFF
--- a/src/fiap-catalog-service-tests/VehicleServiceTests.cs
+++ b/src/fiap-catalog-service-tests/VehicleServiceTests.cs
@@ -254,10 +254,19 @@ namespace fiap_catalog_service_tests
                 Price = 20000,
                 IsReserved = true
             };
+
+            var reserveVehicleDto = new ReserveVehicleDto
+            {
+                VehicleId = vehicleId,
+                OrderId = Guid.NewGuid() // OrderId is not used in this method, but required for the DTO
+            };
+
             _mockRepository.Setup(repo => repo.GetByIdAsync(vehicleId)).ReturnsAsync(vehicle);
             _mockRepository.Setup(repo => repo.UpdateAsync(vehicle)).Returns(Task.CompletedTask);
+
             // Act
-            var result = await _vehicleService.UnreserveVehicleAsync(vehicleId);
+            var result = await _vehicleService.UnreserveVehicleAsync(reserveVehicleDto);
+
             // Assert
             Assert.NotNull(result);
             Assert.False(vehicle.IsReserved);
@@ -270,9 +279,16 @@ namespace fiap_catalog_service_tests
         {
             // Arrange
             var vehicleId = Guid.NewGuid();
+
+            var reserveVehicleDto = new ReserveVehicleDto
+            {
+                VehicleId = vehicleId,
+                OrderId = Guid.NewGuid() // OrderId is not used in this method, but required for the DTO
+            };
+
             _mockRepository.Setup(repo => repo.GetByIdAsync(vehicleId)).ReturnsAsync((Vehicle?)null);
             // Act
-            var result = await _vehicleService.UnreserveVehicleAsync(vehicleId);
+            var result = await _vehicleService.UnreserveVehicleAsync(reserveVehicleDto);
             // Assert
             Assert.Null(result);
             _mockRepository.Verify(repo => repo.UpdateAsync(It.IsAny<Vehicle>()), Times.Never);
@@ -292,9 +308,16 @@ namespace fiap_catalog_service_tests
                 Price = 23000,
                 IsReserved = false
             };
+
+            var reserveVehicleDto = new ReserveVehicleDto
+            {
+                VehicleId = vehicleId,
+                OrderId = Guid.NewGuid() // OrderId is not used in this method, but required for the DTO
+            };
+
             _mockRepository.Setup(repo => repo.GetByIdAsync(vehicleId)).ReturnsAsync(vehicle);
             // Act & Assert
-            await Assert.ThrowsAsync<InvalidOperationException>(() => _vehicleService.UnreserveVehicleAsync(vehicleId));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _vehicleService.UnreserveVehicleAsync(reserveVehicleDto));
             _mockRepository.Verify(repo => repo.UpdateAsync(It.IsAny<Vehicle>()), Times.Never);
         }
     }

--- a/src/fiap-catalog-service/Endpoints/VehicleEndpoints.cs
+++ b/src/fiap-catalog-service/Endpoints/VehicleEndpoints.cs
@@ -136,17 +136,17 @@ namespace fiap_catalog_service.Endpoints
                 }
             });
 
-            app.MapPut("/vehicles/unreserve/{id}", async (Guid id) =>
+            app.MapPut("/vehicles/unreserve", async (ReserveVehicleDto reserveVehicleDto) =>
             {
                 try
                 {
-                    _logger.LogInformation("Liberando reserva do veículo com ID: {Id}", id);
-                    var updatedCar = await _vehicleService.UnreserveVehicleAsync(id);
+                    _logger.LogInformation("Liberando reserva do veículo com ID: {Id}", reserveVehicleDto.VehicleId);
+                    var updatedCar = await _vehicleService.UnreserveVehicleAsync(reserveVehicleDto);
                     return updatedCar is not null ? Results.Ok(updatedCar) : Results.NotFound();
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Erro ao liberar reserva do veículo com ID: {Id}", id);
+                    _logger.LogError(ex, "Erro ao liberar reserva do veículo com ID: {Id}", reserveVehicleDto.VehicleId);
                     return Results.Problem(title: "Erro interno");
                 }
             });

--- a/src/fiap-catalog-service/Services/IVehicleService.cs
+++ b/src/fiap-catalog-service/Services/IVehicleService.cs
@@ -32,7 +32,7 @@ namespace fiap_catalog_service.Services
 
         Task<Vehicle?> ReserveVehicleAsync(ReserveVehicleDto reserveVehicleDto);
 
-        Task<Vehicle?> UnreserveVehicleAsync(Guid id);
+        Task<Vehicle?> UnreserveVehicleAsync(ReserveVehicleDto reserveVehicleDto);
 
         /// <summary>
         /// Deletes a vehicle by its ID.

--- a/src/fiap-catalog-service/Services/VehicleService.cs
+++ b/src/fiap-catalog-service/Services/VehicleService.cs
@@ -79,9 +79,9 @@ namespace fiap_catalog_service.Services
             return vehicle;
         }
 
-        public async Task<Vehicle?> UnreserveVehicleAsync(Guid id)
+        public async Task<Vehicle?> UnreserveVehicleAsync(ReserveVehicleDto reserveVehicleDto)
         {
-            var vehicle = await _vehicleRepository.GetByIdAsync(id);
+            var vehicle = await _vehicleRepository.GetByIdAsync(reserveVehicleDto.VehicleId);
             if (vehicle == null) return null;
             if (!vehicle.IsReserved)
             {

--- a/src/fiap-reserve-vehicle-consumer/Function.cs
+++ b/src/fiap-reserve-vehicle-consumer/Function.cs
@@ -37,11 +37,8 @@ public class Function
                     if (orderEvent.EventType == "CompraRealizada")
                         await ReserveVehicleAsync(orderEvent.ReserveVehicleDto, context);
 
-                    //if (orderEvent.EventType == "CompraCancelada")
-                    //    await UnreserveVehicleAsync(orderEvent.VehicleId, context);
-
-                    //if (orderEvent.EventType == "PagamentoNaoRealizado")
-                    //    await UnreserveVehicleAsync(orderEvent.VehicleId, context);
+                    if (orderEvent.EventType == "CompraCancelada" || orderEvent.EventType == "PagamentoNaoRealizado")
+                        await UnreserveVehicleAsync(orderEvent.ReserveVehicleDto, context);
                 }
             }
             catch (Exception ex)
@@ -69,17 +66,20 @@ public class Function
         }
     }
 
-    private async Task UnreserveVehicleAsync(string vehicleId, ILambdaContext context)
+    private async Task UnreserveVehicleAsync(ReserveVehicleDto reserveVehicleDto, ILambdaContext context)
     {
-        var response = await client.PutAsync($"https://qck4zlo8gl.execute-api.us-east-1.amazonaws.com/vehicles/unreserve/{vehicleId}", null);
+        var json = JsonSerializer.Serialize(reserveVehicleDto);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await client.PutAsync($"https://qck4zlo8gl.execute-api.us-east-1.amazonaws.com/vehicles/unreserve/", content);
 
         if (response.IsSuccessStatusCode)
         {
-            context.Logger.LogLine($"Vehicle {vehicleId} unreserved successfully.");
+            context.Logger.LogLine($"Vehicle {reserveVehicleDto.VehicleId} unreserved successfully.");
         }
         else
         {
-            context.Logger.LogLine($"Failed to unreserve vehicle {vehicleId}. Status code: {response.StatusCode}");
+            context.Logger.LogLine($"Failed to unreserve vehicle {reserveVehicleDto.VehicleId}. Status code: {response.StatusCode}");
         }
     }
 }

--- a/src/fiap-reserve-vehicle-consumer/Models/ReserveVehicleDto.cs
+++ b/src/fiap-reserve-vehicle-consumer/Models/ReserveVehicleDto.cs
@@ -4,5 +4,6 @@
     {
         public required Guid VehicleId { get; init; }
         public required Guid OrderId { get; init; }
+        public required string Status { get; init; }
     }
 }


### PR DESCRIPTION
Updated the `UnreserveVehicleAsync` method to accept a `ReserveVehicleDto` instead of a vehicle ID. Modified the corresponding endpoint in `VehicleEndpoints.cs` and adjusted related test cases in `VehicleServiceTests.cs` to align with the new method signature. Enhanced the unreserve logic in `Function.cs` to handle the new DTO format. Added a `Status` property to `ReserveVehicleDto` for tracking reservation status.