### PR TITLE
Refactor ReserveVehicleDto and add unreserved event logic

### DIFF
--- a/src/fiap-catalog-service-tests/VehicleServiceTests.cs
+++ b/src/fiap-catalog-service-tests/VehicleServiceTests.cs
@@ -169,7 +169,8 @@ namespace fiap_catalog_service_tests
             var reserveVehicleDto = new ReserveVehicleDto
             {
                 VehicleId = vehicle.Id,
-                OrderId = orderId
+                OrderId = orderId,
+                EventType = "CompraRealizada"
             };
 
             _mockRepository.Setup(repo => repo.GetByIdAsync(reserveVehicleDto.VehicleId)).ReturnsAsync(vehicle);
@@ -197,7 +198,8 @@ namespace fiap_catalog_service_tests
             var reserveVehicleDto = new ReserveVehicleDto
             {
                 VehicleId = vehicleId,
-                OrderId = orderId
+                OrderId = orderId,
+                EventType = "CompraRealizada"
             };
 
             _mockRepository.Setup(repo => repo.GetByIdAsync(vehicleId)).ReturnsAsync((Vehicle?)null);
@@ -229,7 +231,8 @@ namespace fiap_catalog_service_tests
             var reserveVehicleDto = new ReserveVehicleDto
             {
                 VehicleId = vehicleId,
-                OrderId = orderId
+                OrderId = orderId,
+                EventType = "CompraRealizada"
             };
 
             _mockRepository.Setup(repo => repo.GetByIdAsync(vehicleId)).ReturnsAsync(vehicle);
@@ -258,7 +261,8 @@ namespace fiap_catalog_service_tests
             var reserveVehicleDto = new ReserveVehicleDto
             {
                 VehicleId = vehicleId,
-                OrderId = Guid.NewGuid() // OrderId is not used in this method, but required for the DTO
+                OrderId = Guid.NewGuid(),
+                EventType = "PagamentoNaoRealizado"
             };
 
             _mockRepository.Setup(repo => repo.GetByIdAsync(vehicleId)).ReturnsAsync(vehicle);
@@ -283,7 +287,8 @@ namespace fiap_catalog_service_tests
             var reserveVehicleDto = new ReserveVehicleDto
             {
                 VehicleId = vehicleId,
-                OrderId = Guid.NewGuid() // OrderId is not used in this method, but required for the DTO
+                OrderId = Guid.NewGuid(),
+                EventType = "PagamentoNaoRealizado"
             };
 
             _mockRepository.Setup(repo => repo.GetByIdAsync(vehicleId)).ReturnsAsync((Vehicle?)null);
@@ -312,7 +317,8 @@ namespace fiap_catalog_service_tests
             var reserveVehicleDto = new ReserveVehicleDto
             {
                 VehicleId = vehicleId,
-                OrderId = Guid.NewGuid() // OrderId is not used in this method, but required for the DTO
+                OrderId = Guid.NewGuid(),
+                EventType = "PagamentoNaoRealizado"
             };
 
             _mockRepository.Setup(repo => repo.GetByIdAsync(vehicleId)).ReturnsAsync(vehicle);

--- a/src/fiap-catalog-service/Dtos/ReserveVehicleDto.cs
+++ b/src/fiap-catalog-service/Dtos/ReserveVehicleDto.cs
@@ -4,5 +4,6 @@
     {
         public required Guid VehicleId { get; init; }
         public required Guid OrderId { get; init; }
+        public required string EventType { get; init; }
     }
 }

--- a/src/fiap-catalog-service/Infrastructure/EventBridge/EventBridgePublisher.cs
+++ b/src/fiap-catalog-service/Infrastructure/EventBridge/EventBridgePublisher.cs
@@ -52,5 +52,39 @@ namespace fiap_catalog_service.Infrastructure.EventBridge
                 throw new InvalidOperationException("Falha ao publicar evento CompraCancelada no EventBridge.");
             }
         }
+
+        public async Task PublishVehicleUnreservedEventAsync(Guid orderId, Guid vehicleId)
+        {
+            var detail = JsonSerializer.Serialize(new
+            {
+                EventType = "ReservaDesfeita",
+                OrderId = orderId,
+                VehicleId = vehicleId,
+                Description = "Reserva de veículo",
+                Amount = 100.00m,
+                Timestamp = DateTime.UtcNow
+            });
+
+            var request = new PutEventsRequest
+            {
+                Entries = new List<PutEventsRequestEntry>
+            {
+                new()
+                {
+                    Detail = detail,
+                    DetailType = "ReservaDesfeita",
+                    Source = "ms.catalogo",
+                    EventBusName = EventBusName
+                }
+            }
+            };
+
+            var response = await _eventBridge.PutEventsAsync(request);
+
+            if (response.FailedEntryCount > 0)
+            {
+                throw new InvalidOperationException("Falha ao publicar evento CompraCancelada no EventBridge.");
+            }
+        }
     }
 }

--- a/src/fiap-catalog-service/Infrastructure/EventBridge/IEventPublisher.cs
+++ b/src/fiap-catalog-service/Infrastructure/EventBridge/IEventPublisher.cs
@@ -3,5 +3,6 @@
     public interface IEventPublisher
     {
         Task PublishVehicleReservedEventAsync(Guid orderId, Guid vehicleId);
+        Task PublishVehicleUnreservedEventAsync(Guid orderId, Guid vehicleId);
     }
 }

--- a/src/fiap-catalog-service/Services/VehicleService.cs
+++ b/src/fiap-catalog-service/Services/VehicleService.cs
@@ -90,6 +90,12 @@ namespace fiap_catalog_service.Services
             vehicle.IsReserved = false;
             vehicle.IsAvailable = true;
             await _vehicleRepository.UpdateAsync(vehicle);
+
+            if(reserveVehicleDto.EventType == "PagamentoNaoRealizado")
+            {
+                await _eventPublisher.PublishVehicleUnreservedEventAsync(reserveVehicleDto.OrderId, vehicle.Id);
+            }
+
             return vehicle;
         }
 

--- a/src/fiap-reserve-vehicle-consumer/Models/ReserveVehicleDto.cs
+++ b/src/fiap-reserve-vehicle-consumer/Models/ReserveVehicleDto.cs
@@ -4,6 +4,6 @@
     {
         public required Guid VehicleId { get; init; }
         public required Guid OrderId { get; init; }
-        public required string Status { get; init; }
+        public required string EventType { get; init; }
     }
 }


### PR DESCRIPTION
- Replaced `Status` property with `EventType` in `ReserveVehicleDto`.
- Updated tests in `VehicleServiceTests.cs` to use the new `EventType`.
- Added `PublishVehicleUnreservedEventAsync` method in `EventBridgePublisher`.
- Updated `IEventPublisher` interface to include the new method.
- Implemented logic in `VehicleService` to publish unreserved events based on `EventType`.